### PR TITLE
Upgrade to debian bookworm

### DIFF
--- a/linux.Dockerfile
+++ b/linux.Dockerfile
@@ -16,7 +16,7 @@ RUN if [ "$SKIP_STEAMCMD" = true ] ; then `
     fi;
 
 #=======================================================================
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG BUILDNODE=unspecified
 ARG SOURCE_COMMIT=unspecified
@@ -25,7 +25,7 @@ HEALTHCHECK NONE
 
 RUN dpkg --add-architecture i386 &&`
     apt-get update && apt-get install -y `
-        ca-certificates lib32gcc1 libtinfo5:i386 libstdc++6:i386 locales locales-all tmux &&`
+        ca-certificates lib32gcc-s1 libtinfo5:i386 libstdc++6:i386 locales locales-all tmux &&`
     apt-get clean &&`
     echo "LC_ALL=en_US.UTF-8" >> /etc/environment &&`
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*;


### PR DESCRIPTION
Use the newer debian:bookworm-slim image as base since debian buster has been superseded.

We have to use package `lib32gcc-s1` since `lib32gcc1` got renamed in the newer repos.
Apart from that I couldn't find any other problems with the newer image. All tests run fine as well.
Console output is also the same.